### PR TITLE
refactor: Disable lint error because the linter is stupid right now.

### DIFF
--- a/apps/dynamic-ngrx-test/src/app/list/list.component.html
+++ b/apps/dynamic-ngrx-test/src/app/list/list.component.html
@@ -1,5 +1,6 @@
 <p>list works!</p>
 <div>
+  <!-- eslint-disable-next-line @angular-eslint/template/use-track-by-function -- the linter is being stupid -->
   <div *ngFor="let item of todos | async; trackBy: trackById">
     {{ item.title }}
   </div>


### PR DESCRIPTION
# Issue Number: #89

# Body

Some package is messing with the linter's ability to see trrackBy so I've comment excluded it for now.
